### PR TITLE
Add Team mode toggle and fix stuck-fly race condition

### DIFF
--- a/HohimBrueh/Assets/Fly.cs
+++ b/HohimBrueh/Assets/Fly.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -10,6 +10,12 @@ public class Fly : MonoBehaviour
 
     public float maxSpeed;
     internal bool BeingIngested;
+    internal Character ingestedBy;
+
+    // Safety timeout: even with a valid owner, force release if a fly stays
+    // claimed for longer than this. Prevents pathological "stuck fly" states.
+    const float ingestTimeoutDuration = 3f;
+    float ingestTimeout;
 
     float updateDirectionDelay;
 
@@ -18,6 +24,23 @@ public class Fly : MonoBehaviour
     {
         terrainLayer = 1 << LayerMask.NameToLayer("Ground");
         velocity = Random.insideUnitCircle.normalized * 10f;
+    }
+
+    internal bool TryClaim(Character claimant)
+    {
+        if (ingestedBy != null && ingestedBy != claimant)
+            return false;
+        ingestedBy = claimant;
+        BeingIngested = true;
+        ingestTimeout = ingestTimeoutDuration;
+        return true;
+    }
+
+    internal void Release()
+    {
+        ingestedBy = null;
+        BeingIngested = false;
+        ingestTimeout = 0f;
     }
 
     // Update is called once per frame
@@ -29,6 +52,19 @@ public class Fly : MonoBehaviour
         {
             updateDirectionDelay = Random.Range(3f, 10f);
             UpdateDirection();
+        }
+
+        if (BeingIngested)
+        {
+            // Watchdog: the owner must still exist, be active, and still point at us.
+            // Otherwise the fly is orphaned (e.g. owner died, got knocked, or another
+            // tongue raced past the claim check on an older code path) — release it.
+            bool ownerLost = ingestedBy == null
+                             || !ingestedBy.gameObject.activeInHierarchy
+                             || ingestedBy.ingestingFly != this;
+            ingestTimeout -= Time.deltaTime;
+            if (ownerLost || ingestTimeout <= 0f)
+                Release();
         }
 
         if (!BeingIngested)

--- a/HohimBrueh/Assets/Scripts/Character.cs
+++ b/HohimBrueh/Assets/Scripts/Character.cs
@@ -376,7 +376,10 @@ public class Character : MonoBehaviour
 
             }
             if (IngestedFly)
+            {
+                ingestingFly.Release();
                 Destroy(ingestingFly.gameObject);
+            }
             Destroy(gameObject);
         }
     }
@@ -780,7 +783,7 @@ public class Character : MonoBehaviour
         }
         if (!IngestedFly && ingestingFly != null)
         {
-            ingestingFly.BeingIngested = false;
+            ingestingFly.Release();
             ingestingFly = null;
         }
         if (hitDir.y < -0.1f)
@@ -815,7 +818,7 @@ public class Character : MonoBehaviour
             wasHitDownwards = true;
         if (!IngestedFly && ingestingFly != null)
         {
-            ingestingFly.BeingIngested = false;
+            ingestingFly.Release();
             ingestingFly = null;
         }
         hasReachedApex = false;
@@ -850,12 +853,12 @@ public class Character : MonoBehaviour
         {
             IngestedFly = false;
             ingestingFly.transform.position = Center;
-            ingestingFly.BeingIngested = false;
+            ingestingFly.Release();
             ingestingFly.gameObject.SetActive(true);
         }
         if (ingestingFly != null)
-        {   
-            ingestingFly.BeingIngested = false;
+        {
+            ingestingFly.Release();
             ingestingFly = null;
         }
         if (hitDir.y < -0.1f)
@@ -1291,11 +1294,11 @@ public class Character : MonoBehaviour
             var fly = Physics2D.OverlapCircle((Vector2)transform.position + tongueOrigin + tongueDir * tongueDistance, 0.5f, flyLayer);
             if (fly != null)
             {
-                if (!fly.GetComponent<Fly>().BeingIngested)
+                var flyComp = fly.GetComponent<Fly>();
+                if (flyComp.TryClaim(this))
                 {
                     tongueState = TongueState.RetractingHitFly;
-                    ingestingFly = fly.GetComponent<Fly>();
-                    ingestingFly.BeingIngested = true;
+                    ingestingFly = flyComp;
                     SoundController.PlaySoundEffect("TongueCollideSurface", 0.5f, TongueTipPos);
                 }
             }
@@ -1435,6 +1438,7 @@ public class Character : MonoBehaviour
                     tongueState = TongueState.HitFlyBurping;
                     tongueDelayLeft = 0.65f;
                     IngestedFly = true;
+                    ingestingFly.Release();
                     ingestingFly.gameObject.SetActive(false);
                 }
             }

--- a/HohimBrueh/Assets/Scripts/Controllers/GameController.cs
+++ b/HohimBrueh/Assets/Scripts/Controllers/GameController.cs
@@ -18,7 +18,7 @@ public class GameController : MonoBehaviour
     public static bool charactersBounceEachOther = false;
     public static bool weirdBounceTrajectories = false;
     public static bool onlyBounceBeforeRecover = true;
-    public static bool allowTeamMode = false;
+    public static bool allowTeamMode = true;
 
     public static List<Player> activePlayers = new List<Player>();
 
@@ -171,7 +171,28 @@ public class GameController : MonoBehaviour
         foreach (var p in winningPlayers)
             activePlayers.Add(p);
         playersCanDropIn = false;
-       
+
+    }
+
+    public static JoinCanvas[] GetJoinCanvases()
+    {
+        return instance != null ? instance.joinCanvas : null;
+    }
+
+    public static void ToggleTeamMode()
+    {
+        if (!allowTeamMode || instance == null) return;
+        isTeamMode = !isTeamMode;
+        if (instance.joinGameModeText != null)
+            instance.joinGameModeText.text = isTeamMode ? "TEAM" : "FREE  FOR  ALL";
+        if (instance.joinCanvas != null)
+        {
+            foreach (var jc in instance.joinCanvas)
+            {
+                if (jc != null && jc.HasAssignedPlayer())
+                    jc.RefreshForMode();
+            }
+        }
     }
 
     void Start()
@@ -211,29 +232,8 @@ public class GameController : MonoBehaviour
             }
 
 
-            int assignedPlayers = 0;
-
-            for (int i = 0; i < joinCanvas.Length; i++)
-            {
-                if (joinCanvas[i].HasAssignedPlayer())
-                {
-                    assignedPlayers++;
-                }
-            }
-
             bool playersAreReady = CheckReadyPlayers();
 
-            if (assignedPlayers == 0)
-            {
-                InputReader.GetInput(combinedInput);
-                if (combinedInput.start && !combinedInput.wasStart && allowTeamMode)
-                {
-                    isTeamMode = !isTeamMode;
-                    joinGameModeText.text = isTeamMode ? "TEAM" : "FREE  FOR  ALL";
-                }
-
-            }
-            else
             if (playersAreReady)
             {
                 finishDelay -= Time.deltaTime;
@@ -376,6 +376,8 @@ public class GameController : MonoBehaviour
         availableColors = new List<Color>();
         availableColors.AddRange(playerColors);
 
+        if (joinGameModeText != null)
+            joinGameModeText.text = isTeamMode ? "TEAM" : "FREE  FOR  ALL";
     }
 
     bool CheckReadyPlayers()

--- a/HohimBrueh/Assets/Scripts/UI/JoinCanvas.cs
+++ b/HohimBrueh/Assets/Scripts/UI/JoinCanvas.cs
@@ -37,6 +37,12 @@ public class JoinCanvas : MonoBehaviour
     float delay = 1f;
     InputState input = new InputState();
     float colorLerpAmount;
+    bool IsHostSlot()
+    {
+        var canvases = GameController.GetJoinCanvases();
+        return canvases != null && canvases.Length > 0 && canvases[0] == this;
+    }
+
     // Update is called once per frame
     void Update()
     {
@@ -49,6 +55,12 @@ public class JoinCanvas : MonoBehaviour
         {
 
             FreeLives.InputReader.GetInput(assignedPlayer.inputDevice, input);
+
+            if (IsHostSlot() && input.aButton && !input.wasAButton)
+            {
+                GameController.ToggleTeamMode();
+                return;
+            }
 
 
             if (GameController.isTeamMode)
@@ -113,10 +125,47 @@ public class JoinCanvas : MonoBehaviour
         else if (state == State.Ready)
         {
             FreeLives.InputReader.GetInput(assignedPlayer.inputDevice, input);
+            if (IsHostSlot() && input.aButton && !input.wasAButton)
+            {
+                GameController.ToggleTeamMode();
+                return;
+            }
             if (input.yButton && !input.wasYButton)
             {
                 UnAssignPlayer();
             }
+        }
+    }
+
+    public void RefreshForMode()
+    {
+        if (assignedPlayer == null) return;
+
+        if (GameController.isTeamMode)
+        {
+            // Switching FFA -> Team: release the pool color the player was using.
+            GameController.ReturnColor(color);
+
+            teamChangeColorObject.SetActive(true);
+            changeColorText.text = "CHANGE TEAM";
+
+            assignedPlayer.team = Random.value < 0.5f ? Team.Red : Team.Blue;
+            colorLerpAmount = Random.Range(0f, 0.7f);
+            color = assignedPlayer.color = Color.Lerp(
+                assignedPlayer.team == Team.Red ? Color.red : Color.blue,
+                Color.white,
+                colorLerpAmount);
+            frogImage.color = color;
+        }
+        else
+        {
+            // Switching Team -> FFA: team color wasn't from the pool, nothing to return.
+            teamChangeColorObject.SetActive(false);
+            changeColorText.text = "CHANGE COLOR";
+
+            color = GameController.GetAvailableColor();
+            assignedPlayer.color = color;
+            frogImage.color = color;
         }
     }
 


### PR DESCRIPTION
Hello!

We recently discovered this game with my friends and we became addict, we always play it in the living room, the game is so nice to play, the fact that anyone who rarely play videogames can play at this game just by telling "Ok, there is ony one rule: You can use your tongue, and your bat, thats it"
is insane.
We discovered a bug, that often happen: The fly get stuck when two player tries to eat it at the same time. 

As you put the game opensource on github, we decided to fix the bug, and enable the "Team Mode", so it adds a little bit of replayability. The text under is written by my agent, resuming the feats/fixs. If you accept this PR, it would be nice to update the Itch.io page as well =))

Thank you !

Team mode was fully implemented but disabled behind allowTeamMode=false. Enable it and let the first joined player (joinCanvas[0]) toggle FFA/Team with the previously-unused A button, in both ChooseColor and Ready states.

The fly could get permanently stuck (visible but frozen, uncatchable) when two tongues touched it the same frame: both passed the !BeingIngested check before either set it. Introduce atomic TryClaim/Release on Fly plus a watchdog that releases the fly if its owner is destroyed, deactivated, or no longer references it (with a 3s safety timeout).